### PR TITLE
Checkout OpenDDS submodules in CI Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,27 +36,28 @@ jobs:
     steps:
       # Clone git repositories
       - name: 'Checkout OpenDDW'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Checkout MPC'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DOCGroup/MPC
           path: MPC
           fetch-depth: 1
       - name: 'Checkout ACE_TAO'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: DOCGroup/ACE_TAO
           ref: ace6tao2
           path: ACE_TAO
           fetch-depth: 1
       - name: 'Checkout OpenDDS'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: OpenDDS/OpenDDS
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1
+          submodules: true
 
       # Get 3rd-party Dependencies
       - name: 'Install openssl and xerces (Linux)'


### PR DESCRIPTION
When the cache misses, rapidJSON includes no longer exist for the remainder of the build, causing issues.