### PR TITLE
Added option to idl2library for including idl's from external directories.

### DIFF
--- a/idl2library.cmake
+++ b/idl2library.cmake
@@ -4,6 +4,7 @@
 # Example:
 #           idl2library(IDLS idl/example.idl idl/std_doc.idl)
 #           idl2library(IDLS idl/example.idl idl/std_doc.idl BUILD_STATIC)
+#           idl2library(IDLS idl/example.idl idl/std_doc.idl INCLUDE_DIRS "${PATH_TO_STD_QOS_IDL}/idl/")
 #
 
 cmake_minimum_required(VERSION 3.20)
@@ -49,9 +50,10 @@ endfunction()
 
 function(idl2library)
     set(options BUILD_STATIC)
-    set(multiValueArgs IDLS)
+    set(singleValueArgs)
+    set(multiValueArgs IDLS INCLUDE_DIRS)
 
-    cmake_parse_arguments(idl2library "BUILD_STATIC" "" "IDLS" ${ARGN})
+    cmake_parse_arguments(PARSE_ARGV 0 idl2library "${options}" "${singleValueArgs}" "${multiValueArgs}")
 
     if (${idl2library_BUILD_STATIC})
         message("Configured to build static libraries.")
@@ -68,6 +70,11 @@ function(idl2library)
             set(IDL_ARG "${IDL_ARG}.idl")
         endif()
         list(APPEND IDL_WISHLIST ${IDL_ARG})
+    endforeach()
+
+    unset(IDL_DIR_WISHLIST)
+    foreach(IDL_DIR_ARG ${idl2library_INCLUDE_DIRS})
+        list(APPEND IDL_DIR_WISHLIST ${IDL_DIR_ARG})
     endforeach()
 
     option(OPENDDS_CPP11_IDL_MAPPING "Use C++11 IDL mapping" OFF)
@@ -162,6 +169,10 @@ function(idl2library)
             endif()
         endforeach()
         list(REMOVE_DUPLICATES current_idl_include_opts)
+
+        foreach(include_dir ${IDL_DIR_WISHLIST})
+            list(APPEND current_idl_include_opts "-I${include_dir}")
+        endforeach()
 
         if(OPENDDS_CPP11_IDL_MAPPING)
             list(APPEND current_idl_include_opts "-Lc++11 ")


### PR DESCRIPTION
Was previously unable to update to OpenDDW because idl2library won't include idl files from directories other than the one it's building in. This change allows a user to point to other include directories. I am working on a project with multiple submodules with their own idl's & in lieu of this I would need to do a major refactor to pull all idl's into one directory.