### PR TITLE
Turn off some warnings for QoS for gcc13

### DIFF
--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -14,6 +14,12 @@
 #include <iostream>
 #include <string>
 
+//gcc13 warnings
+#ifndef WIN32
+#  pragma GCC diagnostic ignored "-Warray-bounds"
+#  pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 namespace
 {
 

--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -17,7 +17,7 @@
 //gcc13 warnings from OpenDDS
 #if !defined(__clang__) && !defined(WIN32)
 #    pragma GCC diagnostic ignored "-Warray-bounds"
-#      pragma GCC diagnostic ignored "-Wstringop-overflow"
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 
 namespace

--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -15,7 +15,7 @@
 #include <string>
 
 //gcc13 warnings
-#if defined(__GNUC__)
+#if __GNUC__ && defined( __has_warning )
 #  pragma GCC diagnostic ignored "-Warray-bounds"
 #  pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif

--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -1,12 +1,12 @@
 #ifdef WIN32
-#pragma warning(push, 0)  //No DDS warnings
+#  pragma warning(push, 0)  //No DDS warnings
 #endif
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/Marked_Default_Qos.h>
 
 #ifdef WIN32
-#pragma warning(pop)
+#  pragma warning(pop)
 #endif
 
 #include "qos_dictionary.h"
@@ -16,8 +16,12 @@
 
 //gcc13 warnings
 #if __GNUC__ && defined( __has_warning )
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#  pragma GCC diagnostic ignored "-Wstringop-overflow"
+#  if __has_warning( "-Warray-bounds" )
+#    pragma GCC diagnostic ignored "-Warray-bounds"
+#  endif
+#  if __has_warning( "-Wstringop-overflow" )
+#      pragma GCC diagnostic ignored "-Wstringop-overflow"
+#  endif
 #endif
 
 namespace

--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -15,7 +15,7 @@
 #include <string>
 
 //gcc13 warnings
-#ifndef WIN32
+#if defined(__GNUC__)
 #  pragma GCC diagnostic ignored "-Warray-bounds"
 #  pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif

--- a/src/qos_dictionary.cpp
+++ b/src/qos_dictionary.cpp
@@ -14,14 +14,10 @@
 #include <iostream>
 #include <string>
 
-//gcc13 warnings
-#if __GNUC__ && defined( __has_warning )
-#  if __has_warning( "-Warray-bounds" )
+//gcc13 warnings from OpenDDS
+#if !defined(__clang__) && !defined(WIN32)
 #    pragma GCC diagnostic ignored "-Warray-bounds"
-#  endif
-#  if __has_warning( "-Wstringop-overflow" )
 #      pragma GCC diagnostic ignored "-Wstringop-overflow"
-#  endif
 #endif
 
 namespace


### PR DESCRIPTION
Note:  These warnings could be due to issues with OpenDDS but turn them off for now.