### PR TITLE
Bump CI's vcpkg git commit hash id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          vcpkgGitCommitId: 898b728edc5e0d12b50015f9cd18247c4257a3eb
+          vcpkgGitCommitId: 74e6536215718009aae747d86d84b78376bf9e09
           runVcpkgInstall: true
 
       # Set Up Build Environments


### PR DESCRIPTION
Problem:
 - CI/CD is failing for Windows machines during the vcpkg step.

Solution:
 - The same issue was seen in the opendds-monitor repository and were most easily fixed by bumping the vcpkg commit id to a recent release tag's id.