### PR TITLE
Bump macOS runner image versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,9 @@ jobs:
           echo "MPC_ROOT=$GITHUB_WORKSPACE/MPC" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ACE_TAO/ACE/lib:$GITHUB_WORKSPACE/OpenDDS/lib" >> $GITHUB_ENV
           CONFIG_OPTIONS+=" --no-tests --std=c++17 --ipv6 --security"
-          if [ '${{ matrix.runner }}' == 'macos-14' ]; then
+          if [ '${{ matrix.runner }}' == 'macos-15' ]; then
+            CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/opt/homebrew/opt/openssl@1.1"
+          elif [ '${{ matrix.runner }}' == 'macos-14' ]; then
             CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/opt/homebrew/opt/openssl@1.1"
           elif [ '${{ runner.os }}' == 'macOS' ]; then
             CONFIG_OPTIONS+=" --xerces3=$(brew --prefix xerces-c) --openssl=/usr/local/opt/openssl@1.1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
           - windows-2022
           - ubuntu-24.04
           - ubuntu-22.04
+          - macos-15
           - macos-14
-          - macos-13
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
Problem:
- macOS 13 runner images are no longer in service

Solution:
- swap in macOS 15 runner images instead, fix any issues